### PR TITLE
RFC 9567 error reporting agent demonstration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,8 +293,9 @@ dependencies = [
 
 [[package]]
 name = "domain"
-version = "0.10.0-dev"
-source = "git+https://github.com/NLnetLabs/domain.git?branch=message-for-slice#b78477b815df89d9341384f9ee6f339feb9f384c"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd50aea158e9a57c9c9075ca7a3dfa4c08d9a468b405832383876f9df85379b"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -310,7 +311,6 @@ dependencies = [
  "smallvec",
  "time",
  "tokio",
- "tokio-rustls",
  "tracing",
 ]
 
@@ -811,21 +811,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.17.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom",
- "libc",
- "spin",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,42 +839,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.21.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki",
- "sct",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "semver"
@@ -947,12 +900,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
@@ -1082,16 +1029,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,12 +1103,6 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "async-lock"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -185,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -200,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -212,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "colorchoice"
@@ -262,6 +268,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
+name = "daemonbase"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e2e198b7af809909368f39c1ab50ef5403756b7d7cd2ba6942555bc146bc874"
+dependencies = [
+ "chrono",
+ "clap",
+ "log",
+ "nix",
+ "serde",
+ "syslog",
+ "toml_edit",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,12 +296,17 @@ name = "domain"
 version = "0.10.0-dev"
 source = "git+https://github.com/NLnetLabs/domain.git?branch=message-for-slice#b78477b815df89d9341384f9ee6f339feb9f384c"
 dependencies = [
+ "arc-swap",
  "bytes",
+ "chrono",
  "futures-util",
+ "hex",
+ "libc",
  "moka",
  "octseq",
  "pin-project-lite",
  "rand",
+ "siphasher",
  "smallvec",
  "time",
  "tokio",
@@ -295,9 +321,18 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "daemonbase",
  "domain",
+ "rand",
  "tokio",
+ "tracing",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -307,6 +342,15 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -396,16 +440,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
-name = "heck"
-version = "0.5.0"
+name = "hashbrown"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -429,6 +496,22 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
@@ -466,6 +549,12 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "memchr"
@@ -518,6 +607,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +639,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
  "libc",
 ]
 
@@ -809,6 +918,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,9 +956,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
-version = "0.11.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -854,6 +969,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syslog"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc7e95b5b795122fafe6519e27629b5ab4232c73ebb2428f568e82b1a457ad3"
+dependencies = [
+ "error-chain",
+ "hostname",
+ "libc",
+ "log",
+ "time",
 ]
 
 [[package]]
@@ -899,10 +1027,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
+ "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -910,6 +1042,16 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tokio"
@@ -950,11 +1092,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+
+[[package]]
+name = "toml_edit"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1273,3 +1433,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ domain   = { version = "0.10", features = ["resolv", "unstable-client-transport"
 tokio    = { version = "1.33", features = ["rt-multi-thread"] }
 
 # For era:
-daemonbase           = { version = "0.1" }
-rand                 = { version = "0.8" }
-tracing              = { version = "0.1", features = ["log"] }
+daemonbase = { version = "0.1" }
+rand       = { version = "0.8" }
+tracing    = { version = "0.1", features = ["log"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.74.0"
 bytes    = "1"
 clap     = { version = "4", features = ["derive", "unstable-doc"] }
 chrono   = { version = "0.4.38", features = [ "alloc", "clock" ] }
-domain   = { git="https://github.com/NLnetLabs/domain.git", branch="message-for-slice", features = ["resolv", "unstable-client-transport", "unstable-server-transport", "siphasher"]}
+domain   = { version = "0.10", features = ["resolv", "unstable-client-transport", "unstable-server-transport", "siphasher"]}
 tokio    = { version = "1.33", features = ["rt-multi-thread"] }
 
 # For era:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,10 @@ rust-version = "1.74.0"
 bytes    = "1"
 clap     = { version = "4", features = ["derive", "unstable-doc"] }
 chrono   = { version = "0.4.38", features = [ "alloc", "clock" ] }
-domain   = { git="https://github.com/NLnetLabs/domain.git", branch="message-for-slice", features = ["resolv", "unstable-client-transport"]}
+domain   = { git="https://github.com/NLnetLabs/domain.git", branch="message-for-slice", features = ["resolv", "unstable-client-transport", "unstable-server-transport", "siphasher"]}
 tokio    = { version = "1.33", features = ["rt-multi-thread"] }
 
-
+# For era:
+daemonbase           = { version = "0.1" }
+rand                 = { version = "0.8" }
+tracing              = { version = "0.1", features = ["log"] }

--- a/src/bin/erma/README.md
+++ b/src/bin/erma/README.md
@@ -1,0 +1,62 @@
+# Erma - Error Report Monitoring Agent
+
+Erma is an implementation of an [RFC 9567](https://datatracker.ietf.org/doc/html/rfc9567#name-monitoring-agent-specificat) monitoring agent.
+
+## Building
+
+```
+$ cargo build --release --bin erma
+```
+
+## Usage
+
+Erma is intended to sit in between two other actors: an authoritative DNS server and an error report propagator.
+
+The authoritative DNS server must respond to EDNS capable clients with an EDNS0 Report-Channel option in its responses to resolvers. The option value should point to where Erma is running.
+
+On applicable error RFC 9567 aware resolvers will then attempt to query Erma using a specific form of TXT query.
+
+On receipt of a valid query Erma will output a CSV version of the received report to its STDOUT in the form: `<report decimal qtype>,<report decimal edns error code>,<report qname>`.
+
+The STDOUT of Erma should be piped into a user supplied report propagation tool which will forward the report to the correct destination where monitoring operators/systems will detect and handle it.
+
+## Testing
+
+A simple local test without an authoritative server or resolver or report propagator can be performed just using Erma and a DNS client tool such as `idns` or `dig`.
+
+1. In terminal **1** run Erma:
+
+    _(By default Erma will bind to port 53 on all interfacess which usually requires root access so we override that for a quick test)_
+```
+$ target/release/erma --addr 127.0.0.1 --port 8053
+```
+
+2. In termnal **2** submit a query to Erma, e.g. using `idns` or `dig`:
+
+    _(The query shown here is the [RFC 9567 example](https://datatracker.ietf.org/doc/html/rfc9567#name-example))_
+```
+$ idns query -s 127.0.0.1 -p 8053 _er.1.broken.test.7._er.a01.agent-domain.example. TXT
+```
+
+3. In terminal **1** on the STDOUT of Erma you should see a CSV formatted version of the received error report:
+
+```
+1,7,broken.test
+```
+
+4. In terminal **2** the query response should be `NOERROR`:
+
+```
+;; ->>HEADER<<- opcode: QUERY, rcode: NOERROR, id: 51847
+;; flags: QR RD; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
+;; QUESTION SECTION:; _er.1.broken.test.7._er.a01.agent-domain.example. TXT     IN
+
+;; ANSWER SECTION:
+_er.1.broken.test.7._er.a01.agent-domain.example. 86400 IN TXT "Report received"
+
+;; Query time: 0 msec
+;; SERVER: 127.0.0.1#8053 (UDP)
+;; WHEN: Tue Apr 30 11:54:11 +02:00 2024
+;; MSG SIZE  rcvd: 142
+```
+

--- a/src/bin/erma/agent.rs
+++ b/src/bin/erma/agent.rs
@@ -1,0 +1,205 @@
+use core::future::Ready;
+
+use std::future::ready;
+use std::str::FromStr;
+
+use tracing::{span, warn, Level};
+
+use domain::base::iana::{Class, Rcode};
+use domain::base::message_builder::{AdditionalBuilder, AnswerBuilder};
+use domain::base::name::{Label, ToLabelIter};
+use domain::base::wire::Composer;
+use domain::base::{CharStr, NameBuilder, ParsedName, RelativeName, Rtype, StreamTarget, Ttl};
+use domain::net::server::message::Request;
+use domain::net::server::service::{CallResult, Service, ServiceError, Transaction};
+use domain::net::server::util::mk_builder_for_target;
+use domain::rdata::rfc1035::TxtBuilder;
+
+//----------- AgentService ---------------------------------------------------
+
+/// A `Service` impl that acts as an [RFC 9567] error reporting agent.
+///
+/// [RFC 9567]: https://datatracker.ietf.org/doc/rfc9567/
+pub struct AgentService<F>
+where
+    F: Fn(u16, u16, RelativeName<Vec<u8>>),
+{
+    // agent_domain: RelativeName?
+    /// A user supplied callback function that will handle received reports.
+    ///
+    /// Will be passed the reported QTYPE, EDNS error code and QNAME as
+    /// arguments.
+    callback: F,
+}
+
+impl<F> AgentService<F>
+where
+    F: Fn(u16, u16, RelativeName<Vec<u8>>),
+{
+    /// Creates a new instance of this service.
+    pub fn new(callback: F) -> Self {
+        Self { callback }
+    }
+
+    /// Process an agent request per RFC 9567, if valid.
+    ///
+    /// Invokes the configured callback to propagate a received error report to
+    /// a handling mechanism.
+    ///
+    /// Returns a DNS TXT response message indicating success or failure.
+    fn process_request<Target: Composer + Default>(
+        &self,
+        request: &Request<Vec<u8>>,
+    ) -> AdditionalBuilder<StreamTarget<Target>> {
+        // https://www.rfc-editor.org/rfc/rfc9567#section-6.3-1
+        // "It is RECOMMENDED that the authoritative server for the agent domain
+        // reply with a positive response (i.e., not with NODATA or NXDOMAIN)
+        // containing a TXT record."
+        let mut response = None;
+
+        if let Ok(question) = request.message().sole_question() {
+            // We're expecting an RFC 9567 compatible query, i.e.:
+            //   - QTYPE: TXT
+            //   - QCLASS: IN?
+            //   - QNAME: _er.<decimal qtype>.<query name labels>.<decimal edns
+            //     error code>._er.<our agent domain>
+            //
+            // The QTYPE therefore has at least 6 labels.
+            //
+            // RFC 9567 doesn't appear to constrain the QCLASS so we will won't
+            // check it but one can imagine that it only makes sense for it to be
+            // IN.
+            //
+            // TODO: Should we enforce that the <our agent domain> part of the
+            // QNAME matches what we think our agent domain is?
+            //
+            // See:
+            // https://www.rfc-editor.org/rfc/rfc9567#name-constructing-the-report-que
+            let qname = question.qname();
+            let qtype = question.qtype();
+            let num_labels = qname.label_count();
+
+            let span = span!(Level::INFO, "Processing", %qname, %qtype);
+            let _enter = span.enter();
+
+            if qtype == Rtype::TXT {
+                if num_labels >= 6 {
+                    match self.parse_qname(qname) {
+                        Err(err) => warn!("QNAME parsing error: {err}"),
+
+                        Ok((rep_qtype, edns_err_code, rep_qname)) => {
+                            (self.callback)(rep_qtype, edns_err_code, rep_qname);
+                            response = Some(self.mk_success_response(request, qname));
+                        }
+                    }
+                } else {
+                    warn!("Insufficient labels in QNAME");
+                }
+            } else {
+                warn!("Invalid QTYPE: {qtype}");
+            }
+        } else {
+            warn!("QDCOUNT != 1");
+        }
+
+        if response.is_none() {
+            response = Some(self.mk_err_response(request, Rcode::FORMERR));
+        }
+
+        response.unwrap().additional()
+    }
+
+    /// Parse a QNAME per the RFC 9567 agent query specification.
+    ///
+    /// Returns Ok((report qtype, report edns error code, report qname)) on
+    /// success, Err(String) otherwise.
+    fn parse_qname(
+        &self,
+        qname: &ParsedName<&[u8]>,
+    ) -> Result<(u16, u16, RelativeName<Vec<u8>>), String> {
+        let mut iter = qname.iter_labels();
+        let _er = iter.next().ok_or("Missing _er label.".to_string())?;
+        let rep_qtype = iter.next().ok_or("Missing QTYPE label.".to_string())?;
+        let mut rep_qname = NameBuilder::new_vec();
+        let mut second_last_label = Option::<&Label>::None;
+        let mut last_label = None;
+        loop {
+            let label = iter
+                .next()
+                .ok_or("Missing QNAME or _er label.".to_string())?;
+            if let Some(label) = second_last_label {
+                rep_qname
+                    .append_label(label.as_slice())
+                    .map_err(|err| format!("Invalid QNAME label: {err}"))?;
+            }
+            if label == "_er" {
+                break;
+            } else {
+                second_last_label = last_label;
+                last_label = Some(label);
+            }
+        }
+        let rep_qname = rep_qname.finish();
+        let edns_err_code = last_label.ok_or("Missing EDNS error code label.".to_string())?;
+
+        let rep_qtype = u16::from_str(&rep_qtype.to_string())
+            .map_err(|err| format!("Invalid QTYPE label: {err}"))?;
+
+        let edns_err_code = u16::from_str(&edns_err_code.to_string())
+            .map_err(|err| format!("Invalid EDNS error code label: {err}"))?;
+
+        Ok((rep_qtype, edns_err_code, rep_qname))
+    }
+
+    /// Construct an RFC 9567 TXT DNS answer response.
+    fn mk_success_response<Target: Composer + Default>(
+        &self,
+        request: &Request<Vec<u8>>,
+        qname: &ParsedName<&[u8]>,
+    ) -> AnswerBuilder<StreamTarget<Target>> {
+        let builder = mk_builder_for_target();
+        let mut answer = builder
+            .start_answer(request.message(), Rcode::NOERROR)
+            .unwrap();
+        let mut txt_builder = TxtBuilder::<Vec<u8>>::new();
+        let txt = {
+            let cs = CharStr::<Vec<u8>>::from_str("Report received").unwrap();
+            txt_builder.append_charstr(&cs).unwrap();
+            txt_builder.finish().unwrap()
+        };
+        answer
+            .push((qname, Class::IN, Ttl::from_days(1), txt))
+            .unwrap();
+        answer
+    }
+
+    /// Construct a DNS error response.
+    fn mk_err_response<Target: Composer + Default>(
+        &self,
+        request: &Request<Vec<u8>>,
+        rcode: Rcode,
+    ) -> AnswerBuilder<StreamTarget<Target>> {
+        let builder = mk_builder_for_target();
+        builder.start_answer(request.message(), rcode).unwrap()
+    }
+}
+
+//--- Service
+
+impl<F> Service<Vec<u8>> for AgentService<F>
+where
+    F: Fn(u16, u16, RelativeName<Vec<u8>>),
+{
+    type Target = Vec<u8>;
+    type Future = Ready<Result<CallResult<Self::Target>, ServiceError>>;
+
+    fn call(
+        &self,
+        request: Request<Vec<u8>>,
+    ) -> Result<Transaction<Self::Target, Self::Future>, ServiceError> {
+        let additional = self.process_request(&request);
+        let item = ready(Ok(CallResult::new(additional)));
+        let txn = Transaction::single(item);
+        Ok(txn)
+    }
+}

--- a/src/bin/erma/main.rs
+++ b/src/bin/erma/main.rs
@@ -1,0 +1,130 @@
+mod agent;
+
+use core::future::pending;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use clap::Parser;
+use rand::RngCore;
+use tokio::net::{TcpListener, UdpSocket};
+
+use agent::AgentService;
+use daemonbase::error::ExitError;
+use daemonbase::logging::{self, Logger};
+use daemonbase::process::{self, Process};
+use domain::base::RelativeName;
+use domain::net::server::buf::VecBufSource;
+use domain::net::server::dgram::{self, DgramServer};
+use domain::net::server::middleware::builder::MiddlewareBuilder;
+use domain::net::server::middleware::chain::MiddlewareChain;
+use domain::net::server::middleware::processors::cookies::CookiesMiddlewareProcessor;
+use domain::net::server::stream::StreamServer;
+use domain::net::server::{stream, ConnectionConfig};
+use tracing::{error, info};
+
+//----------- Args -----------------------------------------------------------
+
+#[derive(clap::Parser)]
+pub struct Args {
+    /// Logging related settings
+    #[command(flatten)]
+    log: logging::Args,
+
+    /// Detach from the terminal
+    #[arg(short, long)]
+    detach: bool,
+
+    /// O/S process behaviour related settings
+    #[command(flatten)]
+    process: process::Args,
+
+    /// The IP address to listen on
+    #[arg(long = "addr", value_name = "LISTEN_ADDRESS", default_value = "[::]")]
+    listen_address: String,
+
+    /// The port to listen on
+    #[arg(long = "port", value_name = "LISTEN_PORT", default_value = "53")]
+    listen_port: u16,
+}
+
+//----------- init_middleware() ----------------------------------------------
+
+fn init_middleware() -> MiddlewareChain<Vec<u8>, Vec<u8>> {
+    let mut middleware = MiddlewareBuilder::<Vec<u8>, Vec<u8>>::standard();
+    let mut server_secret = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut server_secret);
+    let cookies = CookiesMiddlewareProcessor::new(server_secret);
+    middleware.push(cookies.into());
+    middleware.build()
+}
+
+//----------- init_service() -------------------------------------------------
+
+fn init_service() -> Arc<AgentService<impl Fn(u16, u16, RelativeName<Vec<u8>>)>> {
+    let svc = AgentService::new(|qtype, edns_err_code, qname| {
+        println!("{qtype},{edns_err_code},{qname}")
+    });
+    Arc::new(svc)
+}
+
+//----------- main() ---------------------------------------------------------
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<(), ExitError> {
+    Logger::init_logging()?;
+    info!("Logging initialized");
+
+    // Parse command line arguments
+    let args = Args::parse();
+
+    let log = Logger::from_config(&args.log.to_config())?;
+    log.switch_logging(args.detach)?;
+
+    let bind_address = format!("{}:{}", args.listen_address, args.listen_port);
+    let bind_address = bind_address.parse::<SocketAddr>().unwrap();
+
+    let mut process = Process::from_config(args.process.into_config());
+    process.setup_daemon(args.detach)?;
+
+    process.drop_privileges()?;
+
+    // -----------------------------------------------------------------------
+    // Create a service with accompanying middleware chain to answer incoming
+    // requests.
+    // https://www.rfc-editor.org/rfc/rfc9567#section-6.3-2 "The monitoring
+    // agent SHOULD respond to queries received over UDP that have no DNS
+    // Cookie set with a response that has the truncation bit (TC bit) set to
+    // challenge the resolver to requery over TCP."
+    let middleware = init_middleware();
+    let svc = init_service();
+
+    // -----------------------------------------------------------------------
+    // Run a UDP DNS server.
+    let Ok(udpsocket) = UdpSocket::bind(bind_address).await else {
+        error!("Unable to bind to UDP address {bind_address}");
+        std::process::exit(1);
+    };
+
+    let mut config = dgram::Config::default();
+    config.set_middleware_chain(middleware.clone());
+    let srv = DgramServer::with_config(udpsocket, VecBufSource, svc.clone(), config);
+    tokio::spawn(async move { srv.run().await });
+
+    // -----------------------------------------------------------------------
+    // Run a TCP DNS server.
+    let Ok(listener) = TcpListener::bind(bind_address).await else {
+        error!("Unable to bind to UDP address {bind_address}");
+        std::process::exit(1);
+    };
+
+    let mut conn_config = ConnectionConfig::default();
+    conn_config.set_middleware_chain(middleware.clone());
+    let mut config = stream::Config::default();
+    config.set_connection_config(conn_config);
+    let srv = StreamServer::with_config(listener, VecBufSource, svc, config);
+    tokio::spawn(async move { srv.run().await });
+
+    // Run until stopped.
+    pending().await
+}


### PR DESCRIPTION
Initial version of an [RFC 9567](https://datatracker.ietf.org/doc/rfc9567/) error report monitoring agent.

See the [README](https://github.com/NLnetLabs/domain-tools/blob/b9245cdc27092de5271bafe78461c359af9cab46/src/bin/erma/README.md) for more introduction and usage.

Builds upon the existing `introducing-idns` branch of this project for compatability with the domain crate, https://github.com/NLnetLabs/domain for server functionality and https://github.com/NLnetLabs/daemonbase for process daemonisation.

Note: This code uses Tokio Tracing for logging with the intent that it would fit well with the Tokio Tracing logging emitted by the server functionality of the domain crate. However, when combined with daemonbase it's not clear to me how to leverage this properly. For example at present passing `-v` causes all levels of tracing logging within this new tool to be enabled at once irrespective of level, and at the same time no number of `-v` arguments cause the underlying domain crate server side logging to be emitted, at least not so far in my limited testing.

It currently lacks tests. It should at least have unit tests of the QNAME parsing, but I held off adding those yet as I'd like to know if the way I'm parsing the QNAME makes sense, or should I collect it to a Vec or even convert it to a string and parse it that way?